### PR TITLE
SPM bundle support

### DIFF
--- a/NibView.swift
+++ b/NibView.swift
@@ -7,7 +7,8 @@
 //
 
 #if canImport(NibView)
-import NibView #endif
+import NibView
+#endif
 import UIKit
 
 open class NibView: UIView, NibLoadable {

--- a/NibView.swift
+++ b/NibView.swift
@@ -17,6 +17,10 @@ open class NibView: UIView, NibLoadable {
         return String(describing: self)
     }
     
+    open class var bundle: Bundle {
+        return Bundle(for: self)
+    }
+    
     open override func awakeAfter(using aDecoder: NSCoder) -> Any? {
         return nibLoader.awakeAfter(using: aDecoder, super.awakeAfter(using: aDecoder))
     }

--- a/Package.swift
+++ b/Package.swift
@@ -1,22 +1,31 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
-let files = [
+let sourceFiles = [
     "Sources/NibLoadable.swift",
     "Sources/NibLoader.swift",
     "Sources/NibViewController.swift",
     "NibView.swift"
 ]
 
+let excludedFiles = [
+    "Example",
+    "Img",
+    "README.md",
+    "CODEOWNERS",
+    "LICENSE"
+]
+
 let package = Package(
     name: "NibView",
+    defaultLocalization: "en",
     products: [
         .library(name: "NibView", targets: ["NibView"])
     ],
     targets: [
-        .target(name: "NibView", path: "", sources: files)
+        .target(name: "NibView", path: "", exclude: excludedFiles, sources: sourceFiles)
     ],
     swiftLanguageVersions: [.v5]
 )

--- a/Sources/NibLoadable.swift
+++ b/Sources/NibLoadable.swift
@@ -24,11 +24,11 @@ import UIKit
  
  *Optionally* provide custom nib name (defaults to type name):
  
-     static var nibName: String { return "MyCustomView" }
+     class var nibName: String { return "MyCustomView" }
 
  *Optionally* provide custom bundle (defaults to class location):
  
-     static var bundle: Bundle { return Bundle(for: self) }
+     class var bundle: Bundle { return Bundle(for: self) }
  
  # Refencing from IB
  

--- a/Sources/NibLoadable.swift
+++ b/Sources/NibLoadable.swift
@@ -24,7 +24,11 @@ import UIKit
  
  *Optionally* provide custom nib name (defaults to type name):
  
-     class var nibName: String { return "MyCustomView" }
+     static var nibName: String { return "MyCustomView" }
+
+ *Optionally* provide custom bundle (defaults to class location):
+ 
+     static var bundle: Bundle { return Bundle(for: self) }
  
  # Refencing from IB
  
@@ -84,6 +88,7 @@ import UIKit
  */
 public protocol NibLoadable: class {
     static var nibName: String { get }
+    static var bundle: Bundle { get }
 }
 
 // MARK: - From Nib
@@ -94,8 +99,12 @@ public extension NibLoadable where Self: UIView {
          return String(describing: self)
     }
     
+    static var bundle: Bundle {
+        return Bundle(for: self)
+    }
+    
     static func fromNib() -> Self {
-        guard let nib = Bundle(for: self).loadNibNamed(nibName, owner: nil, options: nil) else {
+        guard let nib = self.bundle.loadNibNamed(nibName, owner: nil, options: nil) else {
             fatalError("Failed loading the nib named \(nibName) for 'NibLoadable' view of type '\(self)'.")
         }
         guard let view = (nib.first { $0 is Self }) as? Self else {
@@ -104,4 +113,3 @@ public extension NibLoadable where Self: UIView {
         return view
     }
 }
-


### PR DESCRIPTION
In order to load a nib file from a reuseable Switch package, there has to be a way to override then Bundle(for: self). This is done by bundle property